### PR TITLE
feat: add autocompletion to /passport command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'org.jetbrains.kotlin.jvm'
 }
 
 group = 'net.bnbdiscord'
@@ -26,6 +27,8 @@ repositories {
 dependencies {
     compileOnly "io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT"
 
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
     implementation "de.rapha149.signgui:signgui:2.3.6"
     shadow "de.rapha149.signgui:signgui:2.3.6"
 
@@ -41,8 +44,6 @@ dependencies {
 def targetJavaVersion = 17
 java {
     def javaVersion = JavaVersion.toVersion(targetJavaVersion)
-    sourceCompatibility = javaVersion
-    targetCompatibility = javaVersion
     if (JavaVersion.current() < javaVersion) {
         toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
     }
@@ -63,4 +64,8 @@ processResources {
     filesMatching('plugin.yml') {
         expand props
     }
+}
+
+kotlin {
+    jvmToolchain(targetJavaVersion)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version '2.0.20'
+    }
+}
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
+}
 rootProject.name = 'BorderKit'

--- a/src/main/java/net/bnbdiscord/borderkit/BorderKit.java
+++ b/src/main/java/net/bnbdiscord/borderkit/BorderKit.java
@@ -1,6 +1,7 @@
 package net.bnbdiscord.borderkit;
 
 import net.bnbdiscord.borderkit.commands.PassportCommand;
+import net.bnbdiscord.borderkit.commands.PassportCommandCompleter;
 import net.bnbdiscord.borderkit.database.DatabaseManager;
 import net.bnbdiscord.borderkit.server.ServerRoot;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -23,7 +24,8 @@ public final class BorderKit extends JavaPlugin {
         var passportCommand = Objects.requireNonNull(getCommand("passport"));
         var passportCode = new PassportCommand(this, db, server);
         passportCommand.setExecutor(passportCode);
-//        passportCommand.setTabCompleter(passportCode);
+        var passportCommandCompleter = new PassportCommandCompleter(this, db);
+        passportCommand.setTabCompleter(passportCommandCompleter);
 
     }
 

--- a/src/main/java/net/bnbdiscord/borderkit/commands/PassportCommand.java
+++ b/src/main/java/net/bnbdiscord/borderkit/commands/PassportCommand.java
@@ -31,7 +31,7 @@ import java.util.*;
 
 import static net.bnbdiscord.borderkit.Utils.setCommandBlockStrength;
 
-public class PassportCommand implements CommandExecutor, TabCompleter {
+public class PassportCommand implements CommandExecutor {
     private final Plugin plugin;
     private final NamespacedKey key;
     private final DatabaseManager db;
@@ -477,40 +477,5 @@ public class PassportCommand implements CommandExecutor, TabCompleter {
         state.openMenu();
 
         return true;
-    }
-
-    @Override
-    public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
-        return List.of();
-//        if (strings.length == 0) {
-//            return List.of();
-//        }
-//
-//        try {
-//            var listType = switch (strings[0]) {
-//                case "sign" -> {
-//                    yield "jurisdiction";
-//                }
-////                case "signContinue" -> signContinue(commandSender, strings);
-////                case "nextPage" -> nextPage(commandSender, strings);
-////                case "prevPage" -> prevPage(commandSender, strings);
-////                case "query" -> query(commandSender, strings);
-////                case "attest" -> attest(commandSender, strings);
-////                case "jurisdiction" -> jurisdiction(commandSender, strings);
-////                case "ruleset" -> ruleset(commandSender, strings);
-//                default -> {
-//                    commandSender.sendMessage("Invalid Arguments");
-//                    yield null;
-//                }
-//            };
-//
-//            return switch (listType) {
-////                case "sign" -> List.of("add", "update", "remove");
-//                case "jurisdiction" -> db.getJurisdictionDao().queryForAll().stream().map(Jurisdiction::getCode).toList();
-//                default -> List.of();
-//            };
-//        } catch (SQLException e) {
-//            return List.of();
-//        }
     }
 }

--- a/src/main/java/net/bnbdiscord/borderkit/commands/PassportCommandCompleter.kt
+++ b/src/main/java/net/bnbdiscord/borderkit/commands/PassportCommandCompleter.kt
@@ -1,0 +1,125 @@
+package net.bnbdiscord.borderkit.commands
+
+import net.bnbdiscord.borderkit.database.DatabaseManager
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.bukkit.command.TabCompleter
+import org.bukkit.plugin.Plugin
+
+// Return instead of null for no autocompletion. Returning null autocompletes to the player's username, not nothing.
+val EMPTY = listOf<String>()
+
+class PassportCommandCompleter(val plugin: Plugin, val db: DatabaseManager) : TabCompleter {
+    override fun onTabComplete(
+        sender: CommandSender,
+        command: Command,
+        alias: String,
+        args: Array<String>
+    ): List<String> {
+        if (args.isEmpty()) return EMPTY
+
+        if (args.size == 1) {
+            val result = mutableListOf("attest", "dattest", "query", "ruleset", "sign")
+            if (sender.hasPermission("borderkit.jurisdiction"))
+                result.add("jurisdiction")
+
+            return result.filter { it.startsWith(args[0]) }
+        }
+
+        return when (args[0]) {
+            // /passport attest <jurisdictionCode> <rulesetName> <selector>
+            "attest" -> when (args.size) {
+                2 -> anyJurisdictionCode(args[1])
+                3 -> ruleset(args[1], args[2])
+                4 -> selector(args[3])
+                else -> EMPTY
+            }
+            // /passport dattest <jurisdictionCode1> <rulesetName1> <jurisdictionCode2> <rulesetName2> <selector>
+            "dattest" -> when (args.size) {
+                2 -> anyJurisdictionCode(args[1])
+                3 -> ruleset(args[1], args[2])
+                4 -> anyJurisdictionCode(args[3])
+                5 -> ruleset(args[3], args[4])
+                6 -> selector(args[5])
+                else -> EMPTY
+            }
+            // /passport jurisdiction ...
+            "jurisdiction" -> when {
+                !sender.hasPermission("borderkit.jurisdiction") -> EMPTY
+                args.size == 2 -> listOf("add", "update", "remove")
+                else -> when (args[1]) {
+                    // /passport jurisdiction add <jurisdictionCode: anything> <name: anything>
+                    "add" -> EMPTY
+                    // /passport jurisdiction update <jurisdictionCode> <name: anything>
+                    "update" -> when (args.size) {
+                        3 -> anyJurisdictionCode(args[2])
+                        else -> EMPTY
+                    }
+                    // /passport jurisdiction remove <jurisdictionCode>
+                    "remove" -> when (args.size) {
+                        3 -> anyJurisdictionCode(args[2])
+                        else -> EMPTY
+                    }
+                    else -> EMPTY
+                }
+            }
+            // /passport ruleset ...
+            "ruleset" -> when (args.size) {
+                2 -> listOf("editor", "remove", "set").filter { it.startsWith(args[1]) }
+                else -> when (args[1]) {
+                    // /passport ruleset editor <jurisdictionCode>
+                    "editor" -> when (args.size) {
+                        3 -> jurisdictionCodeWithPermission(args[2], "borderkit.jurisdiction.", sender)
+                        else -> EMPTY
+                    }
+                    // /passport ruleset remove|set <jurisdictionCode> <name>
+                    "remove", "set" -> when (args.size) {
+                        3 -> jurisdictionCodeWithPermission(args[2], "borderkit.jurisdiction.", sender)
+                        4 -> ruleSetWithPermission(args[2], args[3], sender)
+                        else -> EMPTY
+                    }
+                    else -> EMPTY
+                }
+            }
+            // /passport sign <jurisdictionCode>
+            "sign" -> when (args.size) {
+                2 -> jurisdictionCodeWithPermission(args[1], "borderkit.passport.sign.", sender)
+                else -> EMPTY
+            }
+            else -> EMPTY
+        }
+    }
+
+    private fun anyJurisdictionCode(arg: String): List<String> =
+        db.jurisdictionDao.queryBuilder()
+            .where()
+            .like("code", "$arg%")
+            .query()
+            .map { it.code }
+
+    private fun jurisdictionCodeWithPermission(arg: String, permissionPrefix: String, sender: CommandSender): List<String> =
+        anyJurisdictionCode(arg)
+            .filter { sender.hasPermission(permissionPrefix + it.lowercase()) }
+
+    private fun ruleset(jurisdictionCode: String, arg: String): List<String> {
+        return db.rulesetDao.queryBuilder()
+            .where()
+            .eq("jurisdiction_id", jurisdictionCode)
+            .and()
+            .like("name", "$arg%")
+            .query()
+            .map { it.name }
+    }
+
+    private fun ruleSetWithPermission(jurisdictionCode: String, arg: String, sender: CommandSender): List<String> {
+        if (!sender.hasPermission("borderkit.jurisdiction." + jurisdictionCode.lowercase())) return EMPTY
+
+        return ruleset(jurisdictionCode, arg)
+    }
+
+    private fun selector(arg: String): List<String> {
+        val result = mutableListOf("@a", "@e", "@p", "@r", "@s")
+        result.addAll(plugin.server.onlinePlayers.map { it.name })
+        return result.filter { it.lowercase().startsWith(arg.lowercase()) }
+    }
+}

--- a/src/main/java/net/bnbdiscord/borderkit/commands/PassportCommandCompleter.kt
+++ b/src/main/java/net/bnbdiscord/borderkit/commands/PassportCommandCompleter.kt
@@ -46,7 +46,7 @@ class PassportCommandCompleter(val plugin: Plugin, val db: DatabaseManager) : Ta
             // /passport jurisdiction ...
             "jurisdiction" -> when {
                 !sender.hasPermission("borderkit.jurisdiction") -> EMPTY
-                args.size == 2 -> listOf("add", "update", "remove")
+                args.size == 2 -> listOf("add", "update", "remove").filter { it.startsWith(args[1]) }
                 else -> when (args[1]) {
                     // /passport jurisdiction add <jurisdictionCode: anything> <name: anything>
                     "add" -> EMPTY


### PR DESCRIPTION
This pull request adds autocompletion to the `/passport` command. Since this is implemented in Kotlin, it also adds support for using that, as I figured it was more convenient than putting Kotlin support in a separate, rather small PR.

The autocompletion both utilizes database lookups where relevant, and applies permission checks, so that options that cannot be used will not be suggested.

The subcommands `signContinue`, `prevPage` and `nextPage` have intentionally been omitted, since these are internal, and users will never manually run them.

The code is largely written in a declarative KISS manner. Specifically, I tried to have it map roughly 1:1 to the actual command syntax, even if this meant not seizing on opportunities for deduplicating a few lines of code. This should hopefully improve readability and maintainability.

A caveat is that this does not support displaying syntax above the chat line, nor does it highlight errors, as Minecraft-native commands are known for. This is a limitation of the command API exposed by Bukkit. Paper exposes a more powerful API based on [Brigadier](https://github.com/mojang/brigadier), which is also used by Minecraft itself, but we are unfortunately not running a new enough Minecraft version to utilize this. This is thus out of scope for this PR.